### PR TITLE
Fixed warnings + ran cargo fmt

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -7,80 +7,80 @@ use crate::types::Scales;
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct Function<X: AsF64, Y: AsF64, F: Fn(X) -> Y> {
-  #[derivative(Debug = "ignore")]
-  f: F,
-  #[derivative(Debug = "ignore")]
-  _x: PhantomData<X>,
-  #[derivative(Debug = "ignore")]
-  _y: PhantomData<Y>,
+    #[derivative(Debug = "ignore")]
+    f: F,
+    #[derivative(Debug = "ignore")]
+    _x: PhantomData<X>,
+    #[derivative(Debug = "ignore")]
+    _y: PhantomData<Y>,
 }
 
 impl<X: AsF64, Y: AsF64, F: Fn(X) -> Y> Function<X, Y, F> {
-  pub fn new(f: F) -> Function<X, Y, F> {
-    Function {
-      f,
-      _x: PhantomData,
-      _y: PhantomData,
+    pub fn new(f: F) -> Function<X, Y, F> {
+        Function {
+            f,
+            _x: PhantomData,
+            _y: PhantomData,
+        }
     }
-  }
 
-  pub fn at(&self, x: f64) -> f64 {
-    (self.f)(X::from_f64(x)).as_f64()
-  }
+    pub fn at(&self, x: f64) -> f64 {
+        (self.f)(X::from_f64(x)).as_f64()
+    }
 
-  pub fn pt(&self, x: f64) -> (f64, f64) {
-    let y = self.at(x);
-    (x, y)
-  }
+    pub fn pt(&self, x: f64) -> (f64, f64) {
+        let y = self.at(x);
+        (x, y)
+    }
 
-  pub fn rng(&self, x_i: u32, x_f: u32) -> Vec<f64> {
-    (x_i..=x_f)
-      .map(|x| (self.f)(X::from_f64(x.as_f64())).as_f64())
-      .collect()
-  }
+    pub fn rng(&self, x_i: u32, x_f: u32) -> Vec<f64> {
+        (x_i..=x_f)
+            .map(|x| (self.f)(X::from_f64(x.as_f64())).as_f64())
+            .collect()
+    }
 
-  pub fn rng_x(&self, x_i: u32, x_f: u32) -> Vec<(u32, f64)> {
-    (x_i..=x_f)
-      .map(|x| (x, (self.f)(X::from_f64(x.as_f64())).as_f64()))
-      .collect()
-  }
+    pub fn rng_x(&self, x_i: u32, x_f: u32) -> Vec<(u32, f64)> {
+        (x_i..=x_f)
+            .map(|x| (x, (self.f)(X::from_f64(x.as_f64())).as_f64()))
+            .collect()
+    }
 
-  pub fn rng_x_scale(&self, x_i: u32, x_f: u32, scales: &Scales) -> Vec<(f64, f64)> {
-    (x_i..=x_f)
-      .map(|x| {
-        (
-          x as f64 * scales.x,
-          (self.f)(X::from_f64(x.as_f64() * scales.x)).as_f64() * scales.y,
-        )
-      })
-      .collect()
-  }
+    pub fn rng_x_scale(&self, x_i: u32, x_f: u32, scales: &Scales) -> Vec<(f64, f64)> {
+        (x_i..=x_f)
+            .map(|x| {
+                (
+                    x as f64 * scales.x,
+                    (self.f)(X::from_f64(x.as_f64() * scales.x)).as_f64() * scales.y,
+                )
+            })
+            .collect()
+    }
 }
 
 impl<X: AsF64 + Copy, Y: AsF64, F: Fn(X) -> Y> IntoIterator for Function<X, Y, F> {
-  type Item = Y;
-  type IntoIter = FunctionIntoIterator<X, Y, F>;
+    type Item = Y;
+    type IntoIter = FunctionIntoIterator<X, Y, F>;
 
-  fn into_iter(self) -> Self::IntoIter {
-    FunctionIntoIterator {
-      func: self,
-      x: X::from_f64(0_f64),
+    fn into_iter(self) -> Self::IntoIter {
+        FunctionIntoIterator {
+            func: self,
+            x: X::from_f64(0_f64),
+        }
     }
-  }
 }
 
 pub struct FunctionIntoIterator<X: AsF64, Y: AsF64, F: Fn(X) -> Y> {
-  func: Function<X, Y, F>,
-  x: X,
+    func: Function<X, Y, F>,
+    x: X,
 }
 
 impl<X: AsF64 + Copy, Y: AsF64, F: Fn(X) -> Y> Iterator for FunctionIntoIterator<X, Y, F> {
-  type Item = Y;
-  fn next(&mut self) -> Option<Y> {
-    let res = self.func.at(self.x.as_f64());
-    self.x = X::from_f64(self.x.as_f64() + 1.0);
-    Some(Y::from_f64(res))
-  }
+    type Item = Y;
+    fn next(&mut self) -> Option<Y> {
+        let res = self.func.at(self.x.as_f64());
+        self.x = X::from_f64(self.x.as_f64() + 1.0);
+        Some(Y::from_f64(res))
+    }
 }
 
 /// A handy macro for creating [`Function`] instances easier.
@@ -92,32 +92,30 @@ impl<X: AsF64 + Copy, Y: AsF64, F: Fn(X) -> Y> Iterator for FunctionIntoIterator
 /// ```
 /// use tgraph::{MultiGraph, func};
 ///
-/// fn main() {
-///   MultiGraph::new_screen(vec![
-///     func!(|x| f64::sin(x/2f64).abs() * 4f64),
-///     func!(|x: f64| -> f64 {x.ln()} as fn(f64) -> f64),
-///   ]).draw();
-/// }
+/// MultiGraph::new_screen(vec![
+///   func!(|x| f64::sin(x/2f64).abs() * 4f64),
+///   func!(|x: f64| -> f64 {x.ln()} as fn(f64) -> f64),
+/// ]).draw();
 /// ```
 ///
 #[macro_export]
 macro_rules! func {
-  (|$x:ident| $code:expr) => {
-    tgraph::Function::new(|$x: f64| -> f64 { $code } as fn(f64) -> f64)
-  };
-  ($e:expr) => {
-    tgraph::Function::new($e)
-  };
-  ($x:ident -> $code:expr) => {
-    tgraph::Function::new(|$x: f64| -> f64 { $code } as fn(f64) -> f64)
-  };
-  ($x:ident [$xt:ty] -> $code:expr) => {
-    tgraph::Function::new(|$x: $xt| -> f64 { $code } as fn($xt) -> f64)
-  };
-  ($x:ident [$xt:ty] -> $code:expr => [$yt:ty]) => {
-    tgraph::Function::new(|$x: $xt| -> $yt { $code } as fn($xt) -> $yt)
-  };
-  ($x:ident -> $code:expr => [$yt:ty]) => {
-    tgraph::Function::new(|$x: f64| -> $yt { $code } as fn(f64) -> $yt)
-  };
+    (|$x:ident| $code:expr) => {
+        tgraph::Function::new(|$x: f64| -> f64 { $code } as fn(f64) -> f64)
+    };
+    ($e:expr) => {
+        tgraph::Function::new($e)
+    };
+    ($x:ident -> $code:expr) => {
+        tgraph::Function::new(|$x: f64| -> f64 { $code } as fn(f64) -> f64)
+    };
+    ($x:ident [$xt:ty] -> $code:expr) => {
+        tgraph::Function::new(|$x: $xt| -> f64 { $code } as fn($xt) -> f64)
+    };
+    ($x:ident [$xt:ty] -> $code:expr => [$yt:ty]) => {
+        tgraph::Function::new(|$x: $xt| -> $yt { $code } as fn($xt) -> $yt)
+    };
+    ($x:ident -> $code:expr => [$yt:ty]) => {
+        tgraph::Function::new(|$x: f64| -> $yt { $code } as fn(f64) -> $yt)
+    };
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -12,154 +12,155 @@ use crate::types::{Character, ColorWrapper, Scales};
 #[derive(Derivative, TypedBuilder, Debug)]
 #[derivative(Default)]
 pub struct GraphOptions {
-  #[builder(default)]
-  pub color: ColorWrapper,
-  #[builder(default)]
-  pub character: Character,
-  #[derivative(Default(value = "true"))]
-  #[builder(default = true)]
-  pub height_legend: bool,
-  #[derivative(Default)]
-  #[builder(default, setter(into))]
-  pub scales: Scales,
+    #[builder(default)]
+    pub color: ColorWrapper,
+    #[builder(default)]
+    pub character: Character,
+    #[derivative(Default(value = "true"))]
+    #[builder(default = true)]
+    pub height_legend: bool,
+    #[derivative(Default)]
+    #[builder(default, setter(into))]
+    pub scales: Scales,
 }
 
 pub struct Graph {
-  widths: GraphWidths,
-  height: u32,
-  graph_height: u32,
-  pts: Vec<(f64, f64)>,
-  options: GraphOptions,
+    widths: GraphWidths,
+    height: u32,
+    graph_height: u32,
+    pts: Vec<(f64, f64)>,
+    options: GraphOptions,
 }
 
 pub struct GraphWidths {
-  pub total: u32,
-  pub graph: u32,
-  pub height_legend: u32,
+    pub total: u32,
+    pub graph: u32,
+    pub height_legend: u32,
 }
 
 impl Graph {
-  /// `width` refers to the total width of the graph, meaning that the function will be printed from 0 to `width - 1 - max_height_number_digits`
-  pub fn new<X: AsF64, Y: AsF64, F: Fn(X) -> Y>(
-    f: Function<X, Y, F>,
-    width: u32,
-    set_height: Option<u32>,
-  ) -> Graph {
-    Graph::with_options(f, width, set_height, GraphOptions::default())
-  }
-
-  pub fn new_screen<X: AsF64, Y: AsF64, F: Fn(X) -> Y>(f: Function<X, Y, F>) -> Graph {
-    Graph::with_options_screen(f, GraphOptions::default())
-  }
-
-  pub fn with_options<X: AsF64, Y: AsF64, F: Fn(X) -> Y>(
-    f: Function<X, Y, F>,
-    width: u32,
-    set_height: Option<u32>,
-    options: GraphOptions,
-  ) -> Graph {
-    // Generate function (x, y) pairs
-    let mut pts: Vec<(f64, f64)> = f
-      .rng_x_scale(0, width, &options.scales) // TODO Change this to have a Scales struct in options.scales
-      .into_iter()
-      .map(|(x, y)| (x.as_f64(), y))
-      .collect();
-    // Get max y
-    let max = pts
-      .iter()
-      .map(|(_, y)| *y)
-      .fold(f64::NEG_INFINITY, f64::max)
-      .ceil() as u32;
-    // Get digits of maximum number
-    let max_height_digits = successors(Some(max), |&n| (n >= 10).then(|| n / 10)).count() as u32;
-    // Remove elements that shouldn't be printed because of legend
-    for _ in 0..max_height_digits {
-      pts.pop();
+    /// `width` refers to the total width of the graph, meaning that the function will be printed from 0 to `width - 1 - max_height_number_digits`
+    pub fn new<X: AsF64, Y: AsF64, F: Fn(X) -> Y>(
+        f: Function<X, Y, F>,
+        width: u32,
+        set_height: Option<u32>,
+    ) -> Graph {
+        Graph::with_options(f, width, set_height, GraphOptions::default())
     }
-    let height = match set_height {
-      Some(h) => h,
-      None => max + 1,
-    };
-    Graph {
-      // f,
-      widths: GraphWidths {
-        total: width,
-        graph: width - max_height_digits,
-        height_legend: max_height_digits,
-      },
-      height,
-      graph_height: height - 1,
-      pts,
-      options,
+
+    pub fn new_screen<X: AsF64, Y: AsF64, F: Fn(X) -> Y>(f: Function<X, Y, F>) -> Graph {
+        Graph::with_options_screen(f, GraphOptions::default())
     }
-  }
 
-  pub fn with_options_screen<X: AsF64, Y: AsF64, F: Fn(X) -> Y>(
-    f: Function<X, Y, F>,
-    options: GraphOptions,
-  ) -> Graph {
-    let w_screen = console_engine::crossterm::terminal::size().unwrap().0;
-    Graph::with_options(f, w_screen as u32, None, options)
-  }
-
-  pub fn draw(&self) {
-    let mut scr = Screen::new(self.widths.total, self.height);
-
-    self.draw_axis(&mut scr);
-    if self.options.height_legend {
-      self.draw_height_legend(&mut scr);
+    pub fn with_options<X: AsF64, Y: AsF64, F: Fn(X) -> Y>(
+        f: Function<X, Y, F>,
+        width: u32,
+        set_height: Option<u32>,
+        options: GraphOptions,
+    ) -> Graph {
+        // Generate function (x, y) pairs
+        let mut pts: Vec<(f64, f64)> = f
+            .rng_x_scale(0, width, &options.scales) // TODO Change this to have a Scales struct in options.scales
+            .into_iter()
+            .map(|(x, y)| (x.as_f64(), y))
+            .collect();
+        // Get max y
+        let max = pts
+            .iter()
+            .map(|(_, y)| *y)
+            .fold(f64::NEG_INFINITY, f64::max)
+            .ceil() as u32;
+        // Get digits of maximum number
+        let max_height_digits =
+            successors(Some(max), |&n| (n >= 10).then(|| n / 10)).count() as u32;
+        // Remove elements that shouldn't be printed because of legend
+        for _ in 0..max_height_digits {
+            pts.pop();
+        }
+        let height = match set_height {
+            Some(h) => h,
+            None => max + 1,
+        };
+        Graph {
+            // f,
+            widths: GraphWidths {
+                total: width,
+                graph: width - max_height_digits,
+                height_legend: max_height_digits,
+            },
+            height,
+            graph_height: height - 1,
+            pts,
+            options,
+        }
     }
-    self.draw_function(&mut scr);
 
-    scr.draw();
-  }
+    pub fn with_options_screen<X: AsF64, Y: AsF64, F: Fn(X) -> Y>(
+        f: Function<X, Y, F>,
+        options: GraphOptions,
+    ) -> Graph {
+        let w_screen = console_engine::crossterm::terminal::size().unwrap().0;
+        Graph::with_options(f, w_screen as u32, None, options)
+    }
 
-  fn draw_axis(&self, scr: &mut Screen) {
-    // Draw axis
-    scr.h_line(
-      (self.widths.height_legend + 1) as i32,
-      self.graph_height as i32,
-      self.widths.graph as i32,
-      pixel::pxl('_'),
-    );
-    scr.v_line(
-      self.widths.height_legend as i32,
-      0,
-      self.height as i32,
-      pixel::pxl('|'),
-    ); // looks like top boundary is not included
-  }
+    pub fn draw(&self) {
+        let mut scr = Screen::new(self.widths.total, self.height);
 
-  fn draw_height_legend(&self, scr: &mut Screen) {
-    for h in (0..=self.graph_height).map(|y| (y as f64 * self.options.scales.x).round()) {
-      for (index, digit) in h.to_string().chars().enumerate() {
-        scr.set_pxl(
-          index as i32,
-          (self.graph_height as f64 - h / self.options.scales.y)
-            .max(0f64)
-            .round() as i32,
-          pixel::pxl(digit),
+        self.draw_axis(&mut scr);
+        if self.options.height_legend {
+            self.draw_height_legend(&mut scr);
+        }
+        self.draw_function(&mut scr);
+
+        scr.draw();
+    }
+
+    fn draw_axis(&self, scr: &mut Screen) {
+        // Draw axis
+        scr.h_line(
+            (self.widths.height_legend + 1) as i32,
+            self.graph_height as i32,
+            self.widths.graph as i32,
+            pixel::pxl('_'),
         );
-      }
+        scr.v_line(
+            self.widths.height_legend as i32,
+            0,
+            self.height as i32,
+            pixel::pxl('|'),
+        ); // looks like top boundary is not included
     }
-  }
 
-  fn draw_function(&self, scr: &mut Screen) {
-    // Draw points
-    for (x, y) in self.pts.iter() {
-      scr.set_pxl(
-        (x / self.options.scales.x) as i32 + self.widths.height_legend as i32,
-        (self.graph_height as f64 - (y)).round() as i32, // TODO Allow selecting approximation method: round, ceil or cast (as)
-        // Can also put a space (or empty box or something) and color bg
-        pixel::pxl_fg(self.options.character.as_char(), self.options.color.into()),
-      )
+    fn draw_height_legend(&self, scr: &mut Screen) {
+        for h in (0..=self.graph_height).map(|y| (y as f64 * self.options.scales.x).round()) {
+            for (index, digit) in h.to_string().chars().enumerate() {
+                scr.set_pxl(
+                    index as i32,
+                    (self.graph_height as f64 - h / self.options.scales.y)
+                        .max(0f64)
+                        .round() as i32,
+                    pixel::pxl(digit),
+                );
+            }
+        }
     }
-  }
+
+    fn draw_function(&self, scr: &mut Screen) {
+        // Draw points
+        for (x, y) in self.pts.iter() {
+            scr.set_pxl(
+                (x / self.options.scales.x) as i32 + self.widths.height_legend as i32,
+                (self.graph_height as f64 - (y)).round() as i32, // TODO Allow selecting approximation method: round, ceil or cast (as)
+                // Can also put a space (or empty box or something) and color bg
+                pixel::pxl_fg(self.options.character.as_char(), self.options.color.into()),
+            )
+        }
+    }
 }
 
 impl fmt::Display for Graph {
-  fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-    self.draw();
-    Ok(())
-  }
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        self.draw();
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,39 +18,40 @@ pub use crate::types::*;
 pub use console_engine::Color;
 
 #[doc(hidden)]
-fn draw<F: Fn(u32) -> u32>(f: F, character: Character) {
-  // Set width
-  let width = 80;
+#[allow(dead_code)]
+fn draw<F: Fn(u32) -> u32>(f: F, _character: Character) {
+    // Set width
+    let width = 80;
 
-  // Generate values
-  let y: Vec<u32> = (0..=width).map(|x| f(x)).collect();
+    // Generate values
+    let y: Vec<u32> = (0..=width).map(|x| f(x)).collect();
 
-  // Get maximum and minimum value
-  let max = *y.iter().max().unwrap_or(&0);
-  let min = *y.iter().max().unwrap_or(&0);
+    // Get maximum and minimum value
+    let max = *y.iter().max().unwrap_or(&0);
+    let _min = *y.iter().max().unwrap_or(&0);
 
-  // Set graph height
-  let height = max + 1;
+    // Set graph height
+    let height = max + 1;
 
-  let max_height_digits = successors(Some(height), |&n| (n >= 10).then(|| n / 10)).count() as u32;
+    let max_height_digits = successors(Some(height), |&n| (n >= 10).then(|| n / 10)).count() as u32;
 
-  // println!("H: {}; W: {}, y {:?}", height, width, y);
+    // println!("H: {}; W: {}, y {:?}", height, width, y);
 
-  let mut scr = Screen::new(width + 1 + max_height_digits, height + 1);
-  // Draw axis
-  scr.h_line(
-    (max_height_digits + 1) as i32,
-    height as i32,
-    width as i32,
-    pixel::pxl('_'),
-  );
-  scr.v_line(max_height_digits as i32, 0, height as i32, pixel::pxl('|')); // looks like top boundary is not included
+    let mut scr = Screen::new(width + 1 + max_height_digits, height + 1);
+    // Draw axis
+    scr.h_line(
+        (max_height_digits + 1) as i32,
+        height as i32,
+        width as i32,
+        pixel::pxl('_'),
+    );
+    scr.v_line(max_height_digits as i32, 0, height as i32, pixel::pxl('|')); // looks like top boundary is not included
 
-  // Draw height numbers
-  for h in 0..=height {
-    for (index, digit) in h.to_string().chars().enumerate() {
-      scr.set_pxl(index as i32, (height - h) as i32, pixel::pxl(digit));
+    // Draw height numbers
+    for h in 0..=height {
+        for (index, digit) in h.to_string().chars().enumerate() {
+            scr.set_pxl(index as i32, (height - h) as i32, pixel::pxl(digit));
+        }
     }
-  }
-  scr.draw();
+    scr.draw();
 }

--- a/src/multi_graph.rs
+++ b/src/multi_graph.rs
@@ -9,166 +9,167 @@ use crate::graph::{GraphOptions, GraphWidths};
 use crate::traits::AsF64;
 
 pub struct MultiGraph<X: AsF64, Y: AsF64, F: Fn(X) -> Y> {
-  functions: Vec<Function<X, Y, F>>,
-  widths: GraphWidths,
-  height: u32,
-  graph_height: u32,
-  options: MultiGraphOptions,
+    functions: Vec<Function<X, Y, F>>,
+    widths: GraphWidths,
+    height: u32,
+    graph_height: u32,
+    options: MultiGraphOptions,
 }
 
 pub struct MultiGraphOptions(Vec<GraphOptions>);
 
 impl Default for MultiGraphOptions {
-  fn default() -> MultiGraphOptions {
-    let colors = [
-      Color::Red,
-      Color::Blue,
-      Color::Green,
-      Color::Magenta,
-      Color::Cyan,
-      Color::Yellow,
-      Color::DarkRed,
-      Color::DarkBlue,
-      Color::DarkGreen,
-      Color::DarkMagenta,
-      Color::DarkCyan,
-      Color::DarkYellow,
-    ];
-    MultiGraphOptions(
-      (0..12)
-        .map(|i| GraphOptions {
-          color: colors[i].into(),
-          ..GraphOptions::default()
-        })
-        .collect(),
-    )
-  }
+    fn default() -> MultiGraphOptions {
+        let colors = [
+            Color::Red,
+            Color::Blue,
+            Color::Green,
+            Color::Magenta,
+            Color::Cyan,
+            Color::Yellow,
+            Color::DarkRed,
+            Color::DarkBlue,
+            Color::DarkGreen,
+            Color::DarkMagenta,
+            Color::DarkCyan,
+            Color::DarkYellow,
+        ];
+        MultiGraphOptions(
+            (0..12)
+                .map(|i| GraphOptions {
+                    color: colors[i].into(),
+                    ..GraphOptions::default()
+                })
+                .collect(),
+        )
+    }
 }
 
 impl<X: AsF64, Y: AsF64, F: Fn(X) -> Y> MultiGraph<X, Y, F> {
-  pub fn new(
-    f: Vec<Function<X, Y, F>>,
-    width: u32,
-    set_height: Option<u32>,
-  ) -> MultiGraph<X, Y, F> {
-    MultiGraph::with_options(f, width, set_height, MultiGraphOptions::default())
-  }
-
-  pub fn new_screen(f: Vec<Function<X, Y, F>>) -> MultiGraph<X, Y, F> {
-    MultiGraph::with_options_screen(f, MultiGraphOptions::default())
-  }
-
-  pub fn with_options(
-    fs: Vec<Function<X, Y, F>>,
-    width: u32,
-    set_height: Option<u32>,
-    options: MultiGraphOptions,
-  ) -> MultiGraph<X, Y, F> {
-    // Get max y
-    let max = fs
-      .iter()
-      .map(|f| {
-        f.rng(0, width)
-          .into_iter()
-          .reduce(f64::max)
-          .unwrap_or_default()
-      })
-      .reduce(f64::max)
-      .unwrap_or_default()
-      .round() as u32;
-    // Get digits of maximum number
-    let max_height_digits = successors(Some(max), |&n| (n >= 10).then(|| n / 10)).count() as u32;
-
-    let height = match set_height {
-      Some(h) => h,
-      None => max + 1,
-    };
-    MultiGraph {
-      functions: fs,
-      widths: GraphWidths {
-        total: width,
-        graph: width - max_height_digits,
-        height_legend: max_height_digits,
-      },
-      height,
-      graph_height: height - 1,
-      options,
+    pub fn new(
+        f: Vec<Function<X, Y, F>>,
+        width: u32,
+        set_height: Option<u32>,
+    ) -> MultiGraph<X, Y, F> {
+        MultiGraph::with_options(f, width, set_height, MultiGraphOptions::default())
     }
-  }
 
-  pub fn with_options_screen(
-    f: Vec<Function<X, Y, F>>,
-    options: MultiGraphOptions,
-  ) -> MultiGraph<X, Y, F> {
-    let w_screen = console_engine::crossterm::terminal::size().unwrap().0;
-    MultiGraph::with_options(f, w_screen as u32, None, options)
-  }
-
-  pub fn draw(&self) {
-    let mut scr = Screen::new(self.widths.total, self.height);
-
-    self.draw_axis(&mut scr);
-    if self.options.0.get(0).unwrap().height_legend {
-      self.draw_height_legend(&mut scr);
+    pub fn new_screen(f: Vec<Function<X, Y, F>>) -> MultiGraph<X, Y, F> {
+        MultiGraph::with_options_screen(f, MultiGraphOptions::default())
     }
-    self.draw_functions(&mut scr);
 
-    scr.draw();
-  }
+    pub fn with_options(
+        fs: Vec<Function<X, Y, F>>,
+        width: u32,
+        set_height: Option<u32>,
+        options: MultiGraphOptions,
+    ) -> MultiGraph<X, Y, F> {
+        // Get max y
+        let max = fs
+            .iter()
+            .map(|f| {
+                f.rng(0, width)
+                    .into_iter()
+                    .reduce(f64::max)
+                    .unwrap_or_default()
+            })
+            .reduce(f64::max)
+            .unwrap_or_default()
+            .round() as u32;
+        // Get digits of maximum number
+        let max_height_digits =
+            successors(Some(max), |&n| (n >= 10).then(|| n / 10)).count() as u32;
 
-  fn draw_axis(&self, scr: &mut Screen) {
-    // Draw axis
-    scr.h_line(
-      (self.widths.height_legend + 1) as i32,
-      self.graph_height as i32,
-      self.widths.graph as i32,
-      pixel::pxl('_'),
-    );
-    scr.v_line(
-      self.widths.height_legend as i32,
-      0,
-      self.height as i32,
-      pixel::pxl('|'),
-    );
-  }
+        let height = match set_height {
+            Some(h) => h,
+            None => max + 1,
+        };
+        MultiGraph {
+            functions: fs,
+            widths: GraphWidths {
+                total: width,
+                graph: width - max_height_digits,
+                height_legend: max_height_digits,
+            },
+            height,
+            graph_height: height - 1,
+            options,
+        }
+    }
 
-  fn draw_height_legend(&self, scr: &mut Screen) {
-    for h in 0..=self.graph_height {
-      for (index, digit) in h.to_string().chars().enumerate() {
-        scr.set_pxl(
-          index as i32,
-          (self.graph_height - h) as i32,
-          pixel::pxl(digit),
+    pub fn with_options_screen(
+        f: Vec<Function<X, Y, F>>,
+        options: MultiGraphOptions,
+    ) -> MultiGraph<X, Y, F> {
+        let w_screen = console_engine::crossterm::terminal::size().unwrap().0;
+        MultiGraph::with_options(f, w_screen as u32, None, options)
+    }
+
+    pub fn draw(&self) {
+        let mut scr = Screen::new(self.widths.total, self.height);
+
+        self.draw_axis(&mut scr);
+        if self.options.0.get(0).unwrap().height_legend {
+            self.draw_height_legend(&mut scr);
+        }
+        self.draw_functions(&mut scr);
+
+        scr.draw();
+    }
+
+    fn draw_axis(&self, scr: &mut Screen) {
+        // Draw axis
+        scr.h_line(
+            (self.widths.height_legend + 1) as i32,
+            self.graph_height as i32,
+            self.widths.graph as i32,
+            pixel::pxl('_'),
         );
-      }
+        scr.v_line(
+            self.widths.height_legend as i32,
+            0,
+            self.height as i32,
+            pixel::pxl('|'),
+        );
     }
-  }
 
-  fn draw_functions(&self, scr: &mut Screen) {
-    for (i, f) in self.functions.iter().enumerate() {
-      // Draw points
-      for (x, y) in f
-        .rng_x(0, self.widths.graph)
-        .into_iter()
-        .map(|(x, y)| (x, y.round() as u32))
-      {
-        scr.set_pxl(
-          (x + self.widths.height_legend) as i32,
-          (self.graph_height - y) as i32, // TODO Allow selecting approximation method: round, ceil or cast (as)
-          // Can also put a space (or empty box or something) and color bg
-          pixel::pxl_fg(
-            self.options.0.get(i).unwrap().character.as_char(),
-            self.options.0.get(i).unwrap().color.into(),
-          ),
-        )
-      }
+    fn draw_height_legend(&self, scr: &mut Screen) {
+        for h in 0..=self.graph_height {
+            for (index, digit) in h.to_string().chars().enumerate() {
+                scr.set_pxl(
+                    index as i32,
+                    (self.graph_height - h) as i32,
+                    pixel::pxl(digit),
+                );
+            }
+        }
     }
-  }
+
+    fn draw_functions(&self, scr: &mut Screen) {
+        for (i, f) in self.functions.iter().enumerate() {
+            // Draw points
+            for (x, y) in f
+                .rng_x(0, self.widths.graph)
+                .into_iter()
+                .map(|(x, y)| (x, y.round() as u32))
+            {
+                scr.set_pxl(
+                    (x + self.widths.height_legend) as i32,
+                    (self.graph_height - y) as i32, // TODO Allow selecting approximation method: round, ceil or cast (as)
+                    // Can also put a space (or empty box or something) and color bg
+                    pixel::pxl_fg(
+                        self.options.0.get(i).unwrap().character.as_char(),
+                        self.options.0.get(i).unwrap().color.into(),
+                    ),
+                )
+            }
+        }
+    }
 }
 
 impl<X: AsF64, Y: AsF64, F: Fn(X) -> Y> fmt::Display for MultiGraph<X, Y, F> {
-  fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-    self.draw();
-    Ok(())
-  }
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        self.draw();
+        Ok(())
+    }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,19 +1,20 @@
 pub trait AsF64 {
-  fn as_f64(self) -> f64;
-  fn from_f64(v: f64) -> Self;
+    #[allow(clippy::wrong_self_convention)]
+    fn as_f64(self) -> f64;
+    fn from_f64(v: f64) -> Self;
 }
 
 macro_rules! impl_asf64 {
-  ($type:ty) => {
-    impl AsF64 for $type {
-      fn as_f64(self) -> f64 {
-        self as f64
-      }
-      fn from_f64(v: f64) -> $type {
-        v.round() as $type
-      }
-    }
-  };
+    ($type:ty) => {
+        impl AsF64 for $type {
+            fn as_f64(self) -> f64 {
+                self as f64
+            }
+            fn from_f64(v: f64) -> $type {
+                v.round() as $type
+            }
+        }
+    };
 }
 
 impl_asf64!(u8);
@@ -28,43 +29,43 @@ impl_asf64!(i64);
 impl_asf64!(i128);
 
 impl AsF64 for f32 {
-  fn as_f64(self) -> f64 {
-    self as f64
-  }
+    fn as_f64(self) -> f64 {
+        self as f64
+    }
 
-  fn from_f64(v: f64) -> f32 {
-    v as f32
-  }
+    fn from_f64(v: f64) -> f32 {
+        v as f32
+    }
 }
 
 impl AsF64 for f64 {
-  fn as_f64(self) -> f64 {
-    self
-  }
+    fn as_f64(self) -> f64 {
+        self
+    }
 
-  fn from_f64(v: f64) -> f64 {
-    v
-  }
+    fn from_f64(v: f64) -> f64 {
+        v
+    }
 }
 
 pub trait MaybeAsF64 {
-  fn maybe_as_f64(self) -> Option<f64>;
+    fn maybe_as_f64(self) -> Option<f64>;
 }
 
 impl<T> MaybeAsF64 for T
 where
-  T: AsF64,
+    T: AsF64,
 {
-  fn maybe_as_f64(self) -> Option<f64> {
-    Some(self.as_f64())
-  }
+    fn maybe_as_f64(self) -> Option<f64> {
+        Some(self.as_f64())
+    }
 }
 
 impl<T> MaybeAsF64 for Option<T>
 where
-  T: AsF64,
+    T: AsF64,
 {
-  fn maybe_as_f64(self) -> Option<f64> {
-    self.map(|v| v.as_f64())
-  }
+    fn maybe_as_f64(self) -> Option<f64> {
+        self.map(|v| v.as_f64())
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,77 +7,77 @@ use std::fmt::Write;
 #[derive(Copy, Clone, Derivative, Debug)]
 #[derivative(Default)]
 pub enum Character {
-  /// Unicode circle with cross character (¤)
-  CrossCircle,
-  /// Copyright character (®)
-  Copyright,
-  /// Backwards compatibility with `Character::Copyright`
-  Registered,
-  /// Unicode times/multiplication symbol (×)
-  Times,
-  /// Unicode Cyrillic Zhe letter character (ж)
-  CyrillicZhe,
-  /// Unicode Cyrillic millions character (    ҉ )
-  CyrillicMillions,
-  /// Unicode Cyrillic hundred thousands character (    ҈ )        
-  CyrillicHundredThousands,
-  /// Unicode bullet character (•)
-  Bullet,
-  /// Unicode empty bullet character (∘)
-  EmptyBullet,
-  /// Unicode small right-pointing triangle (‣)
-  SmallTriangle,
-  /// Unicode cross with points character (※)
-  CrossPoint,
-  /// ASCII and Unicode asterisk character (∗)
-  Asterisk,
-  #[derivative(Default)]
-  /// **(Default)** Unicode star character (⁕)
-  Star,
-  /// Tuple wrapper for rust `char` type, allows to use
-  Custom(char),
+    /// Unicode circle with cross character (¤)
+    CrossCircle,
+    /// Copyright character (®)
+    Copyright,
+    /// Backwards compatibility with `Character::Copyright`
+    Registered,
+    /// Unicode times/multiplication symbol (×)
+    Times,
+    /// Unicode Cyrillic Zhe letter character (ж)
+    CyrillicZhe,
+    /// Unicode Cyrillic millions character (    ҉ )
+    CyrillicMillions,
+    /// Unicode Cyrillic hundred thousands character (    ҈ )        
+    CyrillicHundredThousands,
+    /// Unicode bullet character (•)
+    Bullet,
+    /// Unicode empty bullet character (∘)
+    EmptyBullet,
+    /// Unicode small right-pointing triangle (‣)
+    SmallTriangle,
+    /// Unicode cross with points character (※)
+    CrossPoint,
+    /// ASCII and Unicode asterisk character (∗)
+    Asterisk,
+    #[derivative(Default)]
+    /// **(Default)** Unicode star character (⁕)
+    Star,
+    /// Tuple wrapper for rust `char` type, allows to use
+    Custom(char),
 }
 
 impl Character {
-  /// Transforms the `Character` variant to the corresponding Rust `char` character. For the `Character::Custom(char)` variant, it returns the `char` that the variant wraps.
-  pub fn as_char(&self) -> char {
-    match self {
-      Character::CrossCircle => '¤',
-      Character::Copyright | Character::Registered => '®',
-      Character::Times => '×',
-      Character::CyrillicZhe => 'ж',
-      Character::CyrillicMillions => '\u{0489}',
-      Character::CyrillicHundredThousands => '\u{0488}',
-      Character::Bullet => '\u{2022}',
-      Character::EmptyBullet => '\u{2218}',
-      Character::SmallTriangle => '\u{2023}',
-      Character::CrossPoint => '\u{203B}',
-      Character::Asterisk => '\u{2217}',
-      Character::Star => '\u{2055}',
-      Character::Custom(c) => *c,
+    /// Transforms the `Character` variant to the corresponding Rust `char` character. For the `Character::Custom(char)` variant, it returns the `char` that the variant wraps.
+    pub fn as_char(&self) -> char {
+        match self {
+            Character::CrossCircle => '¤',
+            Character::Copyright | Character::Registered => '®',
+            Character::Times => '×',
+            Character::CyrillicZhe => 'ж',
+            Character::CyrillicMillions => '\u{0489}',
+            Character::CyrillicHundredThousands => '\u{0488}',
+            Character::Bullet => '\u{2022}',
+            Character::EmptyBullet => '\u{2218}',
+            Character::SmallTriangle => '\u{2023}',
+            Character::CrossPoint => '\u{203B}',
+            Character::Asterisk => '\u{2217}',
+            Character::Star => '\u{2055}',
+            Character::Custom(c) => *c,
+        }
     }
-  }
 }
 
 impl From<char> for Character {
-  /// Wraps the `char` in a `Character::Custom(char)` variant.
-  fn from(c: char) -> Character {
-    Character::Custom(c)
-  }
+    /// Wraps the `char` in a `Character::Custom(char)` variant.
+    fn from(c: char) -> Character {
+        Character::Custom(c)
+    }
 }
 
-impl Into<char> for Character {
-  /// Calls `Character::as_char(&self)`
-  fn into(self) -> char {
-    self.as_char()
-  }
+impl From<Character> for char {
+    /// Calls `Character::as_char(&self)`
+    fn from(val: Character) -> Self {
+        val.as_char()
+    }
 }
 
 impl fmt::Display for Character {
-  /// Prints the character obtained from calling `Character::as_char()` on `self`
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-    f.write_char(self.as_char())
-  }
+    /// Prints the character obtained from calling `Character::as_char()` on `self`
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_char(self.as_char())
+    }
 }
 
 #[derive(Derivative, Copy, Clone)]
@@ -85,43 +85,43 @@ impl fmt::Display for Character {
 pub struct ColorWrapper(Color);
 
 impl Default for ColorWrapper {
-  fn default() -> ColorWrapper {
-    ColorWrapper(Color::Blue)
-  }
+    fn default() -> ColorWrapper {
+        ColorWrapper(Color::Blue)
+    }
 }
 
 impl From<Color> for ColorWrapper {
-  fn from(c: Color) -> ColorWrapper {
-    ColorWrapper(c)
-  }
+    fn from(c: Color) -> ColorWrapper {
+        ColorWrapper(c)
+    }
 }
 
-impl Into<Color> for ColorWrapper {
-  fn into(self) -> Color {
-    self.0
-  }
+impl From<ColorWrapper> for Color {
+    fn from(val: ColorWrapper) -> Self {
+        val.0
+    }
 }
 
 #[derive(Derivative)]
 #[derivative(Default, Debug)]
 pub struct Scales {
-  #[derivative(Default(value = "1f64"))]
-  pub x: f64,
-  #[derivative(Default(value = "1f64"))]
-  pub y: f64,
+    #[derivative(Default(value = "1f64"))]
+    pub x: f64,
+    #[derivative(Default(value = "1f64"))]
+    pub y: f64,
 }
 
 impl From<(f64, f64)> for Scales {
-  fn from((x, y): (f64, f64)) -> Scales {
-    Scales { x, y }
-  }
+    fn from((x, y): (f64, f64)) -> Scales {
+        Scales { x, y }
+    }
 }
 
 impl From<(Option<f64>, Option<f64>)> for Scales {
-  fn from((maybe_x, maybe_y): (Option<f64>, Option<f64>)) -> Scales {
-    Scales {
-      x: maybe_x.unwrap_or(1f64),
-      y: maybe_y.unwrap_or(1f64),
+    fn from((maybe_x, maybe_y): (Option<f64>, Option<f64>)) -> Scales {
+        Scales {
+            x: maybe_x.unwrap_or(1f64),
+            y: maybe_y.unwrap_or(1f64),
+        }
     }
-  }
 }


### PR DESCRIPTION
This PR is for the most part done with the help of various tools like clippy or fmt, just making everything standard, because my editor just converts everything as I code, it's better for it to be completely sanitized first.

If you want to copy my editor config, I use VS Code with the Rust Analyzer extension, with the following custom configuration
```yaml
rust-analyzer.checkOnSave.command: "clippy"
editor.formatOnSave: true
```

Feel free to decline this PR if you don't want this kind of changes

# 🔧 Changes

- Reversed `Into<>` implementations into `From<>` since the From trait automatically implements the Into trait, making the process compatible both ways
- Ran `cargo fmt` on the project, every files got reindented and moved according to standards (sorry)
- Silenced warnings mostly by using the `#[allow()]` directive